### PR TITLE
Require `kumoai>=2.7.0.dev0` for pydantic v2 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "kumoai>=2.5.0",
+    "kumoai>=2.7.0.dev0",
     "pandas",
     "fastmcp",
 ]


### PR DESCRIPTION
Addresses a dep resolution issue for #11:

```console
$ uv pip install kumo_rfm_mcp-0.1.0-py3-none-any.whl
Using Python 3.10.18 environment at: /home/user/work/github.com/kumo-ai/kumo-rfm-mcp/.venv
  × No solution found when resolving dependencies:
  ╰─▶ Because only the following versions of fastmcp are available:
          fastmcp==0.1.0
          fastmcp==0.2.0
          fastmcp==0.3.0
          fastmcp==0.3.1
          fastmcp==0.3.2
          fastmcp==0.3.3
          fastmcp==0.3.4
          fastmcp==0.3.5
          fastmcp==0.4.0
          fastmcp==0.4.1
          fastmcp==1.0
          fastmcp==2.0.0
          fastmcp==2.1.0
          fastmcp==2.1.1
          fastmcp==2.1.2
          fastmcp==2.2.0
          fastmcp==2.2.1
          fastmcp==2.2.2
          fastmcp==2.2.3
          fastmcp==2.2.4
          fastmcp==2.2.5
          fastmcp==2.2.6
          fastmcp==2.2.7
          fastmcp==2.2.8
          fastmcp==2.2.9
          fastmcp==2.2.10
          fastmcp==2.3.0
          fastmcp==2.3.1
          fastmcp==2.3.2
          fastmcp==2.3.3
          fastmcp==2.3.4
          fastmcp==2.3.5
          fastmcp==2.4.0
          fastmcp==2.5.0
          fastmcp==2.5.1
          fastmcp==2.5.2
          fastmcp==2.6.0
          fastmcp==2.6.1
          fastmcp==2.7.0
          fastmcp==2.7.1
          fastmcp==2.8.0
          fastmcp==2.8.1
          fastmcp==2.9.0
          fastmcp==2.9.1
          fastmcp==2.9.2
          fastmcp==2.10.0
          fastmcp==2.10.1
          fastmcp==2.10.2
          fastmcp==2.10.3
          fastmcp==2.10.4
          fastmcp==2.10.5
          fastmcp==2.10.6
          fastmcp==2.11.0
          fastmcp==2.11.1
          fastmcp==2.11.2
          fastmcp==2.11.3
      and fastmcp<=0.2.0 depends on pydantic>=2.5.3, we can conclude that fastmcp<0.3.0 depends on pydantic>=2.5.3.
      And because fastmcp>=0.3.0,<=1.0 depends on pydantic>=2.5.3 and mcp>=1.6.0, we can conclude that fastmcp<2.2.7, mcp<1.6.0, pydantic<2.5.3 are
      incompatible. (1)

      Because only the following versions of mcp are available:
          mcp<=1.6.0
          mcp==1.7.0
          mcp>=1.7.1
      and mcp>=1.6.0,<=1.10.1 depends on pydantic>=2.7.2, we can conclude that mcp>=1.6.0,<=1.10.1 depends on pydantic>=2.7.2.
      And because we know from (1) that fastmcp<2.2.7, mcp<1.6.0, pydantic<2.5.3 are incompatible, we can conclude that fastmcp<2.2.7, mcp<=1.10.1,
      pydantic<2.5.3 are incompatible.
      And because fastmcp>=2.2.7,<=2.2.10 depends on mcp>=1.7.1, we can conclude that fastmcp<2.3.0, mcp<1.7.1, pydantic<2.5.3 are incompatible.
      (2)

      Because only the following versions of mcp are available:
          mcp<=1.7.1
          mcp>=1.8.0
      and mcp>=1.7.1,<=1.10.1 depends on pydantic>=2.7.2, we can conclude that mcp>=1.7.1,<=1.10.1 depends on pydantic>=2.7.2.
      And because we know from (2) that fastmcp<2.3.0, mcp<1.7.1, pydantic<2.5.3 are incompatible, we can conclude that fastmcp<2.3.0, mcp<=1.10.1,
      pydantic<2.5.3 are incompatible.
      And because fastmcp>=2.3.0,<=2.3.3 depends on mcp>=1.8.0, we can conclude that fastmcp<2.3.4, mcp<1.8.0, pydantic<2.5.3 are incompatible. (3)

      Because only the following versions of mcp are available:
          mcp<=1.8.0
          mcp>=1.8.1
      and mcp>=1.8.0,<=1.10.1 depends on pydantic>=2.7.2, we can conclude that mcp>=1.8.0,<=1.10.1 depends on pydantic>=2.7.2.
      And because we know from (3) that fastmcp<2.3.4, mcp<1.8.0, pydantic<2.5.3 are incompatible, we can conclude that fastmcp<2.3.4, mcp<=1.10.1,
      pydantic<2.5.3 are incompatible.
      And because fastmcp==2.3.4 depends on mcp>=1.8.1, we can conclude that fastmcp<2.3.5, mcp<1.8.1, pydantic<2.5.3 are incompatible. (4)

      Because only the following versions of mcp are available:
          mcp<=1.8.1
          mcp>=1.9.0
      and mcp>=1.8.1,<=1.10.1 depends on pydantic>=2.7.2, we can conclude that mcp>=1.8.1,<=1.10.1 depends on pydantic>=2.7.2.
      And because we know from (4) that fastmcp<2.3.5, mcp<1.8.1, pydantic<2.5.3 are incompatible, we can conclude that fastmcp<2.3.5, mcp<=1.10.1,
      pydantic<2.5.3 are incompatible.
      And because fastmcp>=2.3.5,<=2.5.2 depends on mcp>=1.9.0, we can conclude that fastmcp<2.6.0, mcp<1.9.0, pydantic<2.5.3 are incompatible. (5)

      Because only the following versions of mcp are available:
          mcp<=1.9.0
          mcp==1.9.1
          mcp>=1.9.2
      and mcp>=1.9.0,<=1.10.1 depends on pydantic>=2.7.2, we can conclude that mcp>=1.9.0,<=1.10.1 depends on pydantic>=2.7.2.
      And because we know from (5) that fastmcp<2.6.0, mcp<1.9.0, pydantic<2.5.3 are incompatible, we can conclude that fastmcp<2.6.0, mcp<=1.10.1,
      pydantic<2.5.3 are incompatible.
      And because fastmcp>=2.6.0,<=2.8.0 depends on mcp>=1.9.2, we can conclude that fastmcp<2.8.1, mcp<1.9.2, pydantic<2.5.3 are incompatible. (6)

      Because only the following versions of mcp are available:
          mcp<=1.9.2
          mcp==1.9.3
          mcp>=1.9.4
      and mcp>=1.9.2,<=1.10.1 depends on pydantic>=2.7.2, we can conclude that mcp>=1.9.2,<=1.10.1 depends on pydantic>=2.7.2.
      And because we know from (6) that fastmcp<2.8.1, mcp<1.9.2, pydantic<2.5.3 are incompatible, we can conclude that fastmcp<2.8.1, mcp<=1.10.1,
      pydantic<2.5.3 are incompatible.
      And because fastmcp>=2.8.1,<=2.9.1 depends on mcp>=1.9.4 and only the following versions of mcp are available:
          mcp<1.10.0
          mcp>=1.10.0
      we can conclude that fastmcp<2.9.2, mcp<1.9.4, pydantic<2.5.3 are incompatible.
      And because fastmcp>=2.10.0,<=2.11.2 depends on mcp>=1.10.0 and mcp>=1.9.4,<1.10.0, we can conclude that fastmcp<2.11.3, mcp<1.9.4,
      pydantic<2.5.3 are incompatible. (7)

      Because only the following versions of mcp are available:
          mcp<=1.9.4
          mcp>1.10.0
      and mcp>=1.9.4,<=1.10.1 depends on pydantic>=2.7.2, we can conclude that mcp>=1.9.4,<=1.10.1 depends on pydantic>=2.7.2.
      And because we know from (7) that fastmcp<2.11.3, mcp<1.9.4, pydantic<2.5.3 are incompatible, we can conclude that fastmcp<2.11.3,
      mcp<=1.10.1, pydantic<2.5.3 are incompatible. (8)

      Because only the following versions of mcp are available:
          mcp<=1.10.0
          mcp==1.10.1
          mcp==1.11.0
          mcp==1.12.0
          mcp==1.12.1
          mcp==1.12.2
          mcp==1.12.3
          mcp>=1.12.4,<2.0.0
      and mcp>=1.10.0,<=1.10.1 depends on pydantic>=2.7.2, we can conclude that mcp>=1.10.0,<1.11.0 depends on pydantic>=2.7.2.
      And because mcp>=1.11.0,<=1.12.4 depends on pydantic>=2.8.0, we can conclude that mcp>=1.10.0,<=1.12.4 depends on pydantic>=2.7.2.
      And because we know from (8) that fastmcp<2.11.3, mcp<=1.10.1, pydantic<2.5.3 are incompatible, we can conclude that fastmcp<2.11.3,
      mcp<=1.12.4, pydantic<2.5.3 are incompatible.
      And because fastmcp==2.11.3 depends on mcp>=1.12.4 and only the following versions of mcp are available:
          mcp<=1.12.4
          mcp==1.13.0
      we can conclude that all versions of fastmcp, mcp<1.12.4, pydantic<2.5.3 are incompatible.
      And because mcp==1.13.0 depends on pydantic>=2.11.0 and pydantic>=2.8.0, we can conclude that all versions of fastmcp depend on
      pydantic>=2.5.3.
      And because kumoai>=2.5.0 depends on pydantic>=1.10.21,<2 and only the following versions of kumoai are available:
          kumoai<=2.5.0
          kumoai==2.5.1
          kumoai==2.6.0
      we can conclude that all versions of fastmcp and kumoai>=2.5.0 are incompatible.
      And because kumo-rfm-mcp==0.1.0 depends on fastmcp and kumoai>=2.5.0, we can conclude that kumo-rfm-mcp==0.1.0 cannot be used.
      And because only kumo-rfm-mcp==0.1.0 is available and you require kumo-rfm-mcp, we can conclude that your requirements are unsatisfiable.

      hint: Pre-releases are available for `fastmcp` in the requested range (e.g., 2.3.0rc1), but pre-releases weren't enabled (try:
      `--prerelease=allow`)

      hint: Pre-releases are available for `kumoai` in the requested range (e.g., 2.7.0.dev202508151830), but pre-releases weren't enabled (try:
      `--prerelease=allow`)
```