### PR TITLE
Fix mcpb action to test bundling with local code

### DIFF
--- a/.github/workflows/mcpb.yml
+++ b/.github/workflows/mcpb.yml
@@ -29,4 +29,6 @@ jobs:
           python-version: '3.10'
 
       - name: Run MCPB
-        run: python mcpb/server.py
+        run: |
+          echo "." > mcpb/requirements.txt
+          python mcpb/server.py


### PR DESCRIPTION
The MCPB CI action previously installed the pinned PyPI release but accidentally ran against the local source code, testing a broken mix of the two. This change makes CI explicitly install the local package so it properly validates that the current branch code can be bundled and launched.