### PR TITLE
Add HTTP transport for Snowflake MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ Add to your MCP configuration file (*e.g.*, Claude Desktop's `mcp_config.json`):
 }
 ```
 
+### HTTP Transport
+
+For HTTP-native MCP clients such as a Snowflake Native App, run the server with
+`streamable-http` instead of `stdio`:
+
+```bash
+KUMO_API_KEY=<YOUR-KUMO-API-KEY> \
+MCP_BEARER_TOKEN=<SHARED-MCP-TOKEN> \
+python -m kumo_rfm_mcp.server \
+  --transport streamable-http \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --path /mcp
+```
+
+Notes:
+
+- Set `KUMO_API_KEY` up front for headless deployments. This avoids the
+  browser-based OAuth flow.
+- If your MCP client cannot inject environment variables, call the
+  `authenticate` tool with an `api_key` argument once at session start.
+- If `MCP_BEARER_TOKEN` is set, the HTTP endpoint requires
+  `Authorization: Bearer <SHARED-MCP-TOKEN>`.
+
 ### ⚡ MCP Bundle
 
 We provide a single-click installation via our [MCP Bundle (MCPB)](https://github.com/anthropics/mcpb) (*e.g.*, for integration into Claude Desktop):

--- a/kumo_rfm_mcp/http_auth.py
+++ b/kumo_rfm_mcp/http_auth.py
@@ -1,0 +1,38 @@
+import os
+from typing import Final
+
+from fastmcp.server.auth.auth import AccessToken, TokenVerifier
+
+
+MCP_BEARER_TOKEN_ENV: Final[str] = 'MCP_BEARER_TOKEN'
+
+
+class StaticBearerTokenAuth(TokenVerifier):
+    """Authenticate MCP HTTP requests with a shared bearer token."""
+
+    def __init__(self, token: str) -> None:
+        super().__init__()
+        self._token = token
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if token != self._token:
+            return None
+
+        return AccessToken(
+            token=token,
+            client_id='snowflake-native-app',
+            scopes=[],
+        )
+
+
+def get_http_auth() -> StaticBearerTokenAuth | None:
+    """Build HTTP auth from environment variables if configured."""
+    token = os.getenv(MCP_BEARER_TOKEN_ENV)
+    if token is None:
+        return None
+
+    token = token.strip()
+    if not token:
+        return None
+
+    return StaticBearerTokenAuth(token=token)

--- a/kumo_rfm_mcp/http_auth.py
+++ b/kumo_rfm_mcp/http_auth.py
@@ -3,13 +3,11 @@ from typing import Final
 
 from fastmcp.server.auth.auth import AccessToken, TokenVerifier
 
-
 MCP_BEARER_TOKEN_ENV: Final[str] = 'MCP_BEARER_TOKEN'
 
 
 class StaticBearerTokenAuth(TokenVerifier):
     """Authenticate MCP HTTP requests with a shared bearer token."""
-
     def __init__(self, token: str) -> None:
         super().__init__()
         self._token = token

--- a/kumo_rfm_mcp/server.py
+++ b/kumo_rfm_mcp/server.py
@@ -11,8 +11,8 @@ from fastmcp.resources import FileResource
 from pydantic import AnyUrl
 
 import kumo_rfm_mcp
-from kumo_rfm_mcp.http_auth import get_http_auth
 from kumo_rfm_mcp import tools
+from kumo_rfm_mcp.http_auth import get_http_auth
 
 logging.basicConfig(
     level=logging.INFO,
@@ -89,7 +89,8 @@ mcp.add_resource(
 def main() -> None:
     """Main entry point for the CLI command."""
     try:
-        parser = argparse.ArgumentParser(description='Run the KumoRFM MCP server')
+        parser = argparse.ArgumentParser(
+            description='Run the KumoRFM MCP server')
         parser.add_argument(
             '--transport',
             choices=('stdio', 'http', 'streamable-http', 'sse'),

--- a/kumo_rfm_mcp/server.py
+++ b/kumo_rfm_mcp/server.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
+import argparse
 import logging
+import os
 import sys
 from pathlib import Path
+from typing import Final
 
 from fastmcp import FastMCP
 from fastmcp.resources import FileResource
 from pydantic import AnyUrl
 
 import kumo_rfm_mcp
+from kumo_rfm_mcp.http_auth import get_http_auth
 from kumo_rfm_mcp import tools
 
 logging.basicConfig(
@@ -16,15 +20,25 @@ logging.basicConfig(
     stream=sys.stderr)
 logger = logging.getLogger('kumo-rfm-mcp')
 
-mcp = FastMCP(
-    name='KumoRFM (Relational Foundation Model)',
-    instructions=("KumoRFM is a pre-trained Relational Foundation Model (RFM) "
-                  "that generates training-free predictions on any relational "
-                  "multi-table data by interpreting the data as a (temporal) "
-                  "heterogeneous graph. It can be queried via the Predictive "
-                  "Query Language (PQL)."),
-    version=kumo_rfm_mcp.__version__,
-)
+DEFAULT_HTTP_HOST: Final[str] = '127.0.0.1'
+DEFAULT_HTTP_PORT: Final[int] = 8000
+DEFAULT_HTTP_PATH: Final[str] = '/mcp'
+
+
+def create_mcp() -> FastMCP:
+    return FastMCP(
+        name='KumoRFM (Relational Foundation Model)',
+        instructions=("KumoRFM is a pre-trained Relational Foundation Model "
+                      "(RFM) that generates training-free predictions on any "
+                      "relational multi-table data by interpreting the data "
+                      "as a (temporal) heterogeneous graph. It can be queried "
+                      "via the Predictive Query Language (PQL)."),
+        version=kumo_rfm_mcp.__version__,
+        auth=get_http_auth(),
+    )
+
+
+mcp = create_mcp()
 
 # Tools ######################################################################
 tools.register_docs_tools(mcp)
@@ -75,7 +89,42 @@ mcp.add_resource(
 def main() -> None:
     """Main entry point for the CLI command."""
     try:
-        mcp.run(transport='stdio')
+        parser = argparse.ArgumentParser(description='Run the KumoRFM MCP server')
+        parser.add_argument(
+            '--transport',
+            choices=('stdio', 'http', 'streamable-http', 'sse'),
+            default=os.getenv('KUMO_MCP_TRANSPORT', 'stdio'),
+            help='MCP transport to expose. Use streamable-http for Snowflake.',
+        )
+        parser.add_argument(
+            '--host',
+            default=os.getenv('KUMO_MCP_HOST', DEFAULT_HTTP_HOST),
+            help='HTTP bind host for HTTP transports.',
+        )
+        parser.add_argument(
+            '--port',
+            type=int,
+            default=int(os.getenv('KUMO_MCP_PORT', str(DEFAULT_HTTP_PORT))),
+            help='HTTP bind port for HTTP transports.',
+        )
+        parser.add_argument(
+            '--path',
+            default=os.getenv('KUMO_MCP_PATH', DEFAULT_HTTP_PATH),
+            help='HTTP endpoint path for HTTP transports.',
+        )
+        args = parser.parse_args()
+
+        transport = args.transport
+        if transport == 'stdio':
+            mcp.run(transport='stdio')
+            return
+
+        mcp.run(
+            transport=transport,
+            host=args.host,
+            port=args.port,
+            path=args.path,
+        )
     except KeyboardInterrupt:
         logger.info("Server shutdown requested by user")
         sys.exit(0)

--- a/kumo_rfm_mcp/tools/auth.py
+++ b/kumo_rfm_mcp/tools/auth.py
@@ -10,11 +10,14 @@ from kumo_rfm_mcp import SessionManager
 
 
 async def authenticate(
+    api_key: str | None = None,
+    api_url: str | None = None,
 ) -> Literal["KumoRFM session successfully authenticated"]:
     """Authenticate the current KumoRFM session.
 
     Authentication is needed once before predicting or evaluating with the
-    KumoRFM model. If the 'KUMO_API_KEY' environment variable is not set,
+    KumoRFM model. If an API key is provided directly, it is used immediately.
+    Otherwise, if the 'KUMO_API_KEY' environment variable is not set, this
     initiates an OAuth2 authentication flow by opening a browser window for
     user login. Sets the 'KUMO_API_KEY' environment variable upon successful
     authentication.
@@ -24,9 +27,15 @@ async def authenticate(
     if session.is_initialized:
         raise ToolError("KumoRFM session is already authenticated")
 
+    if api_key is not None:
+        api_key = api_key.strip()
+        if not api_key:
+            raise ToolError("Provided API key is empty")
+        os.environ['KUMO_API_KEY'] = api_key
+
     if os.getenv('KUMO_API_KEY') in {None, '', '${user_config.KUMO_API_KEY}'}:
         try:
-            await asyncio.to_thread(rfm.authenticate)
+            await asyncio.to_thread(rfm.authenticate, api_url)
         except Exception as e:
             raise ToolError(
                 f"Failed to authenticate KumoRFM session: {e}") from e

--- a/test/tools/test_auth.py
+++ b/test/tools/test_auth.py
@@ -28,7 +28,7 @@ async def test_authenticate_with_api_key(
 
 @pytest.mark.asyncio
 async def test_authenticate_rejects_empty_api_key(
-    monkeypatch: pytest.MonkeyPatch, ) -> None:
+        monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv('KUMO_API_KEY', raising=False)
 
     with pytest.raises(ToolError, match='Provided API key is empty'):
@@ -37,10 +37,10 @@ async def test_authenticate_rejects_empty_api_key(
 
 @pytest.mark.asyncio
 async def test_authenticate_uses_browser_flow_without_api_key(
-    monkeypatch: pytest.MonkeyPatch, ) -> None:
+        monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv('KUMO_API_KEY', raising=False)
     SessionManager.get_default_session().clear()
-    called = {'api_url': None, 'init': False}
+    called: dict[str, str | bool | None] = {'api_url': None, 'init': False}
 
     def fake_authenticate(api_url: str | None = None) -> None:
         called['api_url'] = api_url

--- a/test/tools/test_auth.py
+++ b/test/tools/test_auth.py
@@ -9,7 +9,8 @@ from kumo_rfm_mcp.tools.auth import authenticate
 
 
 @pytest.mark.asyncio
-async def test_authenticate_with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_authenticate_with_api_key(
+        monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv('KUMO_API_KEY', raising=False)
     called = {'value': False}
 
@@ -27,8 +28,7 @@ async def test_authenticate_with_api_key(monkeypatch: pytest.MonkeyPatch) -> Non
 
 @pytest.mark.asyncio
 async def test_authenticate_rejects_empty_api_key(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     monkeypatch.delenv('KUMO_API_KEY', raising=False)
 
     with pytest.raises(ToolError, match='Provided API key is empty'):
@@ -37,10 +37,9 @@ async def test_authenticate_rejects_empty_api_key(
 
 @pytest.mark.asyncio
 async def test_authenticate_uses_browser_flow_without_api_key(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+    monkeypatch: pytest.MonkeyPatch, ) -> None:
     monkeypatch.delenv('KUMO_API_KEY', raising=False)
-    session = SessionManager.get_default_session().clear()
+    SessionManager.get_default_session().clear()
     called = {'api_url': None, 'init': False}
 
     def fake_authenticate(api_url: str | None = None) -> None:
@@ -60,4 +59,3 @@ async def test_authenticate_uses_browser_flow_without_api_key(
         'api_url': 'https://kumorfm.ai',
         'init': True,
     }
-

--- a/test/tools/test_auth.py
+++ b/test/tools/test_auth.py
@@ -1,0 +1,63 @@
+import os
+
+import pytest
+from fastmcp.exceptions import ToolError
+from kumoai.experimental import rfm
+
+from kumo_rfm_mcp import SessionManager
+from kumo_rfm_mcp.tools.auth import authenticate
+
+
+@pytest.mark.asyncio
+async def test_authenticate_with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv('KUMO_API_KEY', raising=False)
+    called = {'value': False}
+
+    def fake_init() -> None:
+        called['value'] = True
+
+    monkeypatch.setattr(rfm, 'init', fake_init)
+
+    result = await authenticate(api_key='secret-key')
+
+    assert result == "KumoRFM session successfully authenticated"
+    assert os.environ['KUMO_API_KEY'] == 'secret-key'
+    assert called['value'] is True
+
+
+@pytest.mark.asyncio
+async def test_authenticate_rejects_empty_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv('KUMO_API_KEY', raising=False)
+
+    with pytest.raises(ToolError, match='Provided API key is empty'):
+        await authenticate(api_key='   ')
+
+
+@pytest.mark.asyncio
+async def test_authenticate_uses_browser_flow_without_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv('KUMO_API_KEY', raising=False)
+    session = SessionManager.get_default_session().clear()
+    called = {'api_url': None, 'init': False}
+
+    def fake_authenticate(api_url: str | None = None) -> None:
+        called['api_url'] = api_url
+        os.environ['KUMO_API_KEY'] = 'browser-key'
+
+    def fake_init() -> None:
+        called['init'] = True
+
+    monkeypatch.setattr(rfm, 'authenticate', fake_authenticate)
+    monkeypatch.setattr(rfm, 'init', fake_init)
+
+    result = await authenticate(api_url='https://kumorfm.ai')
+
+    assert result == "KumoRFM session successfully authenticated"
+    assert called == {
+        'api_url': 'https://kumorfm.ai',
+        'init': True,
+    }
+


### PR DESCRIPTION
## Summary
- add HTTP MCP transport support so the server can run with `streamable-http` instead of only `stdio`
- add optional bearer-token protection for the HTTP endpoint via `MCP_BEARER_TOKEN`
- allow the `authenticate` tool to accept an API key directly so headless clients can avoid browser OAuth
- document the Snowflake-oriented HTTP startup flow

## Testing
- `./.venv/bin/pytest kumo-rfm-mcp/test`
- manual HTTP smoke test against `python -m kumo_rfm_mcp.server --transport streamable-http`
