### PR TITLE
Fix ImportError with kumoai>=2.21.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ server-info.json
 .DS_Store
 .claude/
 uv.lock
+.worktrees

--- a/kumo_rfm_mcp/tools/graph.py
+++ b/kumo_rfm_mcp/tools/graph.py
@@ -7,7 +7,10 @@ import pandas as pd
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from kumoai.experimental import rfm
-from kumoai.experimental.rfm.infer.dtype import infer_dtype
+try:
+    from kumoai.rfm.infer.dtype import infer_dtype
+except ImportError:
+    from kumoai.experimental.rfm.infer.dtype import infer_dtype
 from kumoai.graph import Edge
 from kumoapi.typing import Dtype, Stype
 from pydantic import Field

--- a/kumo_rfm_mcp/tools/graph.py
+++ b/kumo_rfm_mcp/tools/graph.py
@@ -7,10 +7,12 @@ import pandas as pd
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from kumoai.experimental import rfm
+
 try:
     from kumoai.rfm.infer.dtype import infer_dtype
 except ImportError:
     from kumoai.experimental.rfm.infer.dtype import infer_dtype
+
 from kumoai.graph import Edge
 from kumoapi.typing import Dtype, Stype
 from pydantic import Field

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ from typing import Any
 import pandas as pd
 import pytest
 from kumoai.experimental import rfm
-from kumoai.experimental.rfm.rfm import Explanation
+from kumoai.experimental.rfm import Explanation
 from kumoapi.rfm import Explanation as ExplanationConfig
 from kumoapi.task import TaskType
 from pytest import TempPathFactory


### PR DESCRIPTION
## Summary

- `kumoai` 2.21.0 moved `rfm.infer` out of the `experimental` namespace into `kumoai.rfm.infer`
- The `experimental.rfm` compatibility shim re-exports top-level classes but does **not** include the `infer` submodule
- This caused `kumo-rfm-mcp` 0.3.0 to crash on startup with `ModuleNotFoundError: No module named 'kumoai.experimental.rfm.infer'` for any user with `kumoai>=2.21.0`
- Fix uses a `try/except` to support both old (`<2.21.0`) and new (`>=2.21.0`) kumoai

## Test plan

- [x] Verify server starts with `kumoai>=2.21.0` (e.g. 2.22.0)
- [x] Verify server starts with `kumoai<2.21.0` (e.g. 2.20.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)