### PR TITLE
Backport: Fix ImportError with kumoai>=2.21.0 (for 0.3.1 patch release)

### DIFF
--- a/kumo_rfm_mcp/tools/graph.py
+++ b/kumo_rfm_mcp/tools/graph.py
@@ -7,7 +7,10 @@ import pandas as pd
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from kumoai.experimental import rfm
-from kumoai.experimental.rfm.infer.dtype import infer_dtype
+try:
+    from kumoai.rfm.infer.dtype import infer_dtype
+except ImportError:
+    from kumoai.experimental.rfm.infer.dtype import infer_dtype
 from kumoai.graph import Edge
 from kumoapi.typing import Dtype, Stype
 from pydantic import Field

--- a/kumo_rfm_mcp/tools/graph.py
+++ b/kumo_rfm_mcp/tools/graph.py
@@ -7,10 +7,12 @@ import pandas as pd
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from kumoai.experimental import rfm
+
 try:
     from kumoai.rfm.infer.dtype import infer_dtype
 except ImportError:
     from kumoai.experimental.rfm.infer.dtype import infer_dtype
+
 from kumoai.graph import Edge
 from kumoapi.typing import Dtype, Stype
 from pydantic import Field

--- a/mcpb/requirements.txt
+++ b/mcpb/requirements.txt
@@ -1,1 +1,1 @@
-kumo-rfm-mcp==0.2.0
+kumo-rfm-mcp==0.3.1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ from typing import Any
 import pandas as pd
 import pytest
 from kumoai.experimental import rfm
-from kumoai.experimental.rfm.rfm import Explanation
+from kumoai.experimental.rfm import Explanation
 from kumoapi.rfm import Explanation as ExplanationConfig
 from kumoapi.task import TaskType
 from pytest import TempPathFactory


### PR DESCRIPTION
Backport of #108 onto `v0.3` for a `0.3.1` patch release.

## Summary

- `kumoai` 2.21.0 moved `rfm.infer` out of the `experimental` namespace — the compat shim does not cover the `infer` submodule, so `kumo-rfm-mcp==0.3.0` crashes on startup with `ModuleNotFoundError` for any user with `kumoai>=2.21.0`
- Also fixes the same pattern in `test/conftest.py` (`kumoai.experimental.rfm.rfm` → `kumoai.experimental.rfm`)
- Updates `mcpb/requirements.txt` from `==0.2.0` to `==0.3.1` so the DXT bundle uses the fixed version

## After merging

Run the **Trigger Release** workflow on `v0.3` with `dry-run: false` to produce `0.3.1` on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)