### PR TITLE
ci: pin GitHub Actions by SHA for NVIDIA migration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
         with:
           python-version: '3.10'
           activate-environment: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
         with:
           python-version: '3.10'
           activate-environment: true


### PR DESCRIPTION
## Summary
- Pin only third-party GitHub Actions and reusable workflows to full 40-character commit SHAs.
- Leave GitHub-owned (`actions/*`, `github/*`) and Kumo-owned (`kumo-ai/*`) references at their existing tags or branches; NVIDIA allowlisting applies to third-party actions.

## Validation
- Parsed all `.github` YAML files.
- `git diff --check`
- Static policy scan confirms no mutable third-party `uses:` reference remains.