### PR TITLE
ci: scope Actions SHA version comments

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -38,7 +38,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Upload to TestPyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           repository-url: https://test.pypi.org/legacy/
           user: __token__
@@ -46,7 +46,7 @@ jobs:
           verbose: true
 
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           repository-url: https://upload.pypi.org/legacy/
           user: __token__


### PR DESCRIPTION
Remove version comments from GitHub and Verified Marketplace Actions. Per NVIDIA migration policy, version comments are used only beside SHA pins for unverified third-party actions. No action reference or workflow behavior changes.